### PR TITLE
Added bitmap cache with background processes

### DIFF
--- a/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/boxForOop..st
+++ b/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/boxForOop..st
@@ -4,6 +4,7 @@ boxForOop: o
 	box := RSBox new.
 	box model: o.
 	box paint: (colorProvider colorForOop: o).
+	box popup.
 	self enableInspectOnClickForBox: box.
 	scaling value: box.
 	self contextMenuForBox: box.

--- a/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/buildMemorySpaceIn..st
+++ b/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/buildMemorySpaceIn..st
@@ -1,15 +1,15 @@
 building
 buildMemorySpaceIn: aCanvas
 	| controller |
-	aCanvas addAll: (scopedOop collect: [ :anOop | self boxForOop: anOop ]).
-	
-	RSGridLayout new
-		gapSize: 1;
-		on: aCanvas nodes.
+	aCanvas add: bitmap.
+	self createBitmap.
 	controller := RSCanvasController new.
 	controller configuration
-		maxScale: 100000;
+		maxScale: 5;
 		minScale: 0.00001.
-	aCanvas addInteraction: controller.
+	
+	aCanvas 
+		addInteraction: controller;
+		when: RSMouseClick send: #mouseClick: to: self.
 	self contextMenuForCanvas: aCanvas.
 	aCanvas signalUpdate.

--- a/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/contextMenuForCanvas..st
+++ b/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/contextMenuForCanvas..st
@@ -2,8 +2,7 @@ building
 contextMenuForCanvas: canvas
 	| menuActivable |
 	menuActivable := RSMenuActivable new.
-	menuActivable menuDo: [ :menu :element | 
-		
+	menuActivable menuDo: [ :menu :element |
 		menu 
 			add: 'No scaling'
 			target: self

--- a/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/createBitmap.st
+++ b/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/createBitmap.st
@@ -1,0 +1,26 @@
+building
+createBitmap
+	
+	[ | newCanvas mainCanvas rectangle |
+		newCanvas := RSCanvas new.
+		nodes := self createNodes.
+		newCanvas addAll: nodes.
+		
+		mainCanvas := bitmap canvas.
+		mainCanvas removeKey: #firstScale.
+		mainCanvas propertyAt: #rtree put: (RSPolyphemusRTree withAll: nodes).
+		rectangle := newCanvas encompassingRectangle.
+		mainCanvas controllerInteraction configuration maxScale: (rectangle extent * 0.01) max.
+		newCanvas camera
+			zoomToFit: mainCanvas extent
+			rectangle: rectangle.
+		newCanvas extent: rectangle extent * newCanvas camera scale.
+		bitmap form: newCanvas asForm.
+		mainCanvas propertyAt: #originalCamera put: newCanvas camera.
+		mainCanvas
+			when: RSScaleChangedEvent send: #updateView: to: self;
+			when: RSPositionChangedEvent send: #updateView: to: self;
+			removeKey: #encompassingRectangle;
+			zoomToFit;
+			signalUpdate.
+	 ] forkAt: Processor userBackgroundPriority

--- a/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/createNodes.st
+++ b/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/createNodes.st
@@ -1,0 +1,9 @@
+building
+createNodes
+	| shapes |
+	shapes := scopedOop collect: [ :anOop | self boxForOop: anOop ] as: RSGroup.
+	RSGridLayout new
+		gapSize: 1;
+		on: shapes.
+	Transcript show: shapes size asString; show: ' elements! holy crap!!!';cr.
+	^ shapes

--- a/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/initializePresenters.st
+++ b/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/initializePresenters.st
@@ -1,5 +1,5 @@
 initialization
 initializePresenters
-
-	memorySpace := self instantiate: SpRoassalPresenter.
-	memorySpace script: [ :canvas | self buildMemorySpaceIn: canvas ].
+	memorySpace := self newRoassal.
+	bitmap := self newEmptyBitmap.
+	memorySpace script: [ :canvas | self buildMemorySpaceIn: canvas ]

--- a/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/mouseClick..st
+++ b/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/mouseClick..st
@@ -1,0 +1,14 @@
+events
+mouseClick: evt
+	| mainCanvas rtree point shapes camera |
+	mainCanvas := evt canvas.
+	rtree := mainCanvas propertyAt: #rtree ifAbsent: [ ^ self ].
+	camera := mainCanvas propertyAt: #originalCamera.
+	point := evt position.
+	point := (camera fromPixelToSpace: evt position)+((camera canvas extent/2)/camera scale).
+
+	shapes := rtree nodesWithPoint: point.
+	shapes size traceCr.
+	shapes size = 1 ifFalse: [  ^ self ].
+	
+	"shapes first announce: evt class new."

--- a/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/newEmptyBitmap.st
+++ b/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/newEmptyBitmap.st
@@ -1,0 +1,13 @@
+initialization
+newEmptyBitmap
+	"this method is going to create a new empty bitmap with a loading logo "
+	| shape canvas |
+	shape := RSBitmap new.
+	canvas := RSCanvas new.
+	canvas extent: 300 asPoint.
+	canvas add: (RSLabel new
+		text: 'Loading data...';
+		color: 'black';
+		yourself).
+	shape form: canvas asForm.
+	^ shape

--- a/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/updateView..st
+++ b/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/updateView..st
@@ -1,0 +1,16 @@
+building
+updateView: evt
+
+	| mainCanvas scale position process firstScale |
+	mainCanvas := bitmap canvas.
+	scale := evt camera scale.
+	position := evt camera position.
+	firstScale := mainCanvas propertyAt: #firstScale ifAbsentPut: [ scale ].
+	mainCanvas propertyAt: #viewport ifPresent: [ :view | 
+		view remove.
+		mainCanvas removeKey: #viewport ].
+	scale > firstScale ifFalse: [ 
+		^ self ].
+	mainCanvas propertyAt: #viewProcess ifPresent: [ :p | p terminate ].
+	process := [ self updateViewPort: evt ] forkAt: Processor userBackgroundPriority.
+	mainCanvas propertyAt: #viewProcess put: process.

--- a/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/updateViewPort..st
+++ b/Polyphemus-Memory.package/AbstractMemoryPresenter.class/instance/updateViewPort..st
@@ -1,0 +1,28 @@
+building
+updateViewPort: evt
+	| viewport newCanvas mainCanvas ext camera scale rtree |
+	mainCanvas := bitmap canvas.
+	viewport := mainCanvas
+		propertyAt: #viewport
+		ifAbsentPut: [ RSBitmap new ].
+	camera := mainCanvas propertyAt: #originalCamera.
+	rtree := mainCanvas propertyAt: #rtree.
+	newCanvas := RSCanvas new.
+	
+	"newCanvas color: Color transparent."
+	ext := mainCanvas extent.
+	scale := mainCanvas camera scale * camera scale.
+	
+	newCanvas camera
+		scale: scale;
+		position: (mainCanvas camera position * (1 /camera scale))+camera position.
+	newCanvas extent: mainCanvas extent.
+	newCanvas addAll: (rtree nodesIntersetcsRectangle: newCanvas visibleRectangle).
+	
+	viewport form: newCanvas asForm.
+	viewport 
+		isFixed: true;
+		position: ext / 2.
+	mainCanvas add: viewport.
+	viewport pushBack.
+	mainCanvas signalUpdate.

--- a/Polyphemus-Memory.package/AbstractMemoryPresenter.class/properties.json
+++ b/Polyphemus-Memory.package/AbstractMemoryPresenter.class/properties.json
@@ -13,7 +13,9 @@
 		"queryInput",
 		"updateOutput",
 		"updateBlock",
-		"reifiedMemory"
+		"reifiedMemory",
+		"bitmap",
+		"nodes"
 	],
 	"name" : "AbstractMemoryPresenter",
 	"type" : "normal"

--- a/Polyphemus-Memory.package/MemoryInspector.class/instance/initializeWindow..st
+++ b/Polyphemus-Memory.package/MemoryInspector.class/instance/initializeWindow..st
@@ -1,0 +1,5 @@
+initialization
+initializeWindow: aWindowPresenter
+	aWindowPresenter
+		title: self title;
+		initialExtent: 900@ 700

--- a/Polyphemus-Memory.package/RSPolyphemusRTree.class/README.md
+++ b/Polyphemus-Memory.package/RSPolyphemusRTree.class/README.md
@@ -1,0 +1,1 @@
+This RTree is prepared for PolyphemusRTree to have a balanced tree

--- a/Polyphemus-Memory.package/RSPolyphemusRTree.class/class/withAll..st
+++ b/Polyphemus-Memory.package/RSPolyphemusRTree.class/class/withAll..st
@@ -1,0 +1,5 @@
+instance creation
+withAll: aCollection
+	^ self new
+		addAll: aCollection;
+		yourself

--- a/Polyphemus-Memory.package/RSPolyphemusRTree.class/instance/addAll..st
+++ b/Polyphemus-Memory.package/RSPolyphemusRTree.class/instance/addAll..st
@@ -1,0 +1,5 @@
+adding
+addAll: aCollection
+	aCollection ifEmpty: [ ^ self ].
+	root := RSRNode new.
+	root rectangleAddAll: aCollection axis: true.

--- a/Polyphemus-Memory.package/RSPolyphemusRTree.class/properties.json
+++ b/Polyphemus-Memory.package/RSPolyphemusRTree.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "akevalion 5/12/2022 10:09",
+	"super" : "RSRenderTree",
+	"category" : "Polyphemus-Memory-Presenters",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "RSPolyphemusRTree",
+	"type" : "normal"
+}

--- a/Polyphemus-Memory.package/RSRNode.extension/instance/listsFor.axis.center..st
+++ b/Polyphemus-Memory.package/RSRNode.extension/instance/listsFor.axis.center..st
@@ -1,0 +1,17 @@
+*Polyphemus-Memory
+listsFor: aCollection axis: aBoolean center: point
+	| listA listB |
+	listA := RSGroup new.
+	listB := RSGroup new.
+	aCollection do: [ :shape |
+		aBoolean ifTrue: [ 
+			(shape position x < point x 
+				ifTrue: [ listA ]
+				ifFalse: [ listB ]) add: shape
+		]ifFalse: [ 
+			(shape position y < point y
+				ifTrue: [ listA ]
+				ifFalse: [ listB ]) add: shape
+		]
+	].
+	^ { listA. listB }

--- a/Polyphemus-Memory.package/RSRNode.extension/instance/rectangleAddAll.axis..st
+++ b/Polyphemus-Memory.package/RSRNode.extension/instance/rectangleAddAll.axis..st
@@ -1,0 +1,19 @@
+*Polyphemus-Memory
+rectangleAddAll: aCollection axis: aBoolean
+	aCollection ifEmpty: [ ^ self error: 'should not' ].
+	aCollection size = 1 ifTrue: [ 
+		contents := aCollection first.
+		rectangle := contents encompassingRectangle.
+	] ifFalse: [ | center lists |
+		rectangle := aCollection encompassingRectangle.
+		center := rectangle floatCenter.
+		lists := self listsFor: aCollection axis: aBoolean center: center.
+		(lists anySatisfy: [ :list | list isEmpty ])
+			ifTrue: [ lists := self listsFor: aCollection axis: aBoolean not center: center ].
+		(lists anySatisfy: [:list | list isEmpty ])
+			ifTrue: [ self error: 'listFor: error' ].
+		left := self class new.
+		left rectangleAddAll: lists first axis: aBoolean not.
+		right := self class new.
+		right rectangleAddAll: lists second axis: aBoolean not. 
+	]

--- a/Polyphemus-Memory.package/RSRNode.extension/properties.json
+++ b/Polyphemus-Memory.package/RSRNode.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "RSRNode"
+}


### PR DESCRIPTION
This pull request enables a quatree for big visualizations.

This uses 2 bitmaps, 1 bitmap for the entire visualization and second bitmap for a quality visualization.
check `AbstractMemoryPresenter >> #mouseClick:` to propagate the event to the nodes.
This is not a general solution for Roassal3, Roassal3 will support R-tree in a future.