### PR TITLE
InstancesOf speedup + oopHash 0 based

### DIFF
--- a/Polyphemus-Builder.package/OOPBuilder.class/instance/initializeClassOop..st
+++ b/Polyphemus-Builder.package/OOPBuilder.class/instance/initializeClassOop..st
@@ -10,5 +10,5 @@ initializeClassOop: anOop
 		ifFalse: [
 			memory setHashBitsOf: anOop to: oopClassIndexinstalation.
 			self ensureClassPageExistsFor: oopClassIndexinstalation.
-			memory classAtIndex: oopClassIndexinstalation  put: anOop.
+			memory classAtIndex: oopClassIndexinstalation put: anOop.
 			].

--- a/Polyphemus-Object.package/OOPAbstractClass.class/instance/instancesOop.st
+++ b/Polyphemus-Object.package/OOPAbstractClass.class/instance/instancesOop.st
@@ -1,3 +1,3 @@
 query
 instancesOop
-	^ memory select: [ :anOop | anOop oopClass = self ]
+	^ memory select: [ :anOop | anOop oopClassTag = self oopClassIndex ]

--- a/Polyphemus-Object.package/OOPAbstractClass.class/instance/oopClassIndex.st
+++ b/Polyphemus-Object.package/OOPAbstractClass.class/instance/oopClassIndex.st
@@ -1,5 +1,5 @@
 testing
 oopClassIndex
-	"This class index is 1 based, like the class table slots.
-	However the classTableObject is 0 based, if you access the simulator"
-	^ self oopHash + 1
+	"This class index is 0 based, like the class table slots.
+	However the reifiedClassTableObject is 1 based"
+	^ self oopHash

--- a/Polyphemus-Tests.package/OOPBuilderTest.class/instance/testClassInstalationAtIndex.st
+++ b/Polyphemus-Tests.package/OOPBuilderTest.class/instance/testClassInstalationAtIndex.st
@@ -1,9 +1,8 @@
 tests-class
 testClassInstalationAtIndex
-	"reifiedOop is 1 based, vm is 0 based"
 	oopBuilder 
 		oopIsClass: true;
-		oopClassIndexinstalation: 2047.
+		oopClassIndexinstalation: 2048.
 	reifiedOop := self buildObject.
 	
 	self assert: (self reifyOop: reifiedOop address) oopClassIndex equals: 2048

--- a/Polyphemus-Tests.package/OOPBuilderTest.class/instance/testClassInstalationAtIndexInEmptyPage.st
+++ b/Polyphemus-Tests.package/OOPBuilderTest.class/instance/testClassInstalationAtIndexInEmptyPage.st
@@ -1,9 +1,8 @@
 tests-class
 testClassInstalationAtIndexInEmptyPage
-	"reifiedOop is 1 based, vm is 0 based"
 	oopBuilder 
 		oopIsClass: true;
 		oopClassIndexinstalation: 2049.
 	reifiedOop := self buildObject.
 	
-	self assert: (self reifyOop: reifiedOop address) oopClassIndex equals: 2050
+	self assert: (self reifyOop: reifiedOop address) oopClassIndex equals: 2049

--- a/Polyphemus-Tests.package/ReifiedMemoryTest.class/instance/testPreFindClassNamed.st
+++ b/Polyphemus-Tests.package/ReifiedMemoryTest.class/instance/testPreFindClassNamed.st
@@ -1,4 +1,4 @@
 running
 testPreFindClassNamed
 	self assert: (reifiedMemory preFindClassNamed: #PCSmallInteger)
-		equals: (self reifyOop: (memory integerObjectOf: 42)) oopClass oopClassIndex - 1
+		equals: (self reifyOop: (memory integerObjectOf: 42)) oopClass oopClassIndex

--- a/Polyphemus-Tests.package/VMOOPClassTest.class/instance/testOopClassIndex.st
+++ b/Polyphemus-Tests.package/VMOOPClassTest.class/instance/testOopClassIndex.st
@@ -4,4 +4,4 @@ testOopClassIndex
 	| integerClass |
 	integerClass := (self reifyOop: (memory integerObjectOf: 42)) oopClass.
 	
-	self assert: integerClass address equals: (reifiedMemory reifiedClassTable classAtIndex: integerClass oopClassIndex)
+	self assert: integerClass address equals: (reifiedMemory reifiedClassTable classAtIndex: integerClass oopClassIndex + 1)


### PR DESCRIPTION
This PR should speedup the instancesOf search by using the tag rather than the class.
However it showed that the classTag is 1 based in Polyphemus.
Which is nice when you're only touching reified stuff, but not the point most of the time.
This is interesting because we have to set our limits between what is internal polyphemus, and what is API.

@Alisu could you take a look ?
I'm not a 100% on my decision tbh.
